### PR TITLE
Update Lint on line 49: src/CerberusPM/Cerberus/command/subcommand/HelpSubcommand.php

### DIFF
--- a/src/CerberusPM/Cerberus/command/subcommand/HelpSubcommand.php
+++ b/src/CerberusPM/Cerberus/command/subcommand/HelpSubcommand.php
@@ -44,5 +44,3 @@ class HelpSubcommand extends BaseSubCommand {
         //TODO
     }
 } 
- 
- ?>


### PR DESCRIPTION
this Pull request simply supplies a patch to a lint on line 49 at src/CerberusPM/Cerberus/command/subcommand/HelpSubcommand.php
the lint was a `?>` discouraged on pocketmine